### PR TITLE
use travis with docker

### DIFF
--- a/.travis.dapple-docker-entry
+++ b/.travis.dapple-docker-entry
@@ -1,0 +1,7 @@
+#!/bin/sh
+exec docker run --rm -it --name=dapple-$$ \
+-e HOME -e USER=travis -e GROUP=`id -gn` \
+-e entrypoint -w "`pwd`" -v "`pwd`:`pwd`" \
+-v "$HOME/.dapplerc:$HOME/.dapplerc" \
+-v "$HOME/.npm:$HOME/.npm" \
+rainbeam/dapple "$@"

--- a/.travis.dapplerc
+++ b/.travis.dapplerc
@@ -1,0 +1,2 @@
+environments:
+    env: default

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+sudo: required
+dist: trusty
+
+services:
+  docker
+
+git:
+  submodules: false
+
+before_install:
+  - id
+  - docker pull rainbeam/dapple
+  - docker images
+  - cp .travis.dapplerc $HOME/.dapplerc
+  - git submodule update --init --recursive
+
+script:
+  - ./.travis.dapple-docker-entry test


### PR DESCRIPTION
Alternative to #29 that also addresses #10.

Here we use a docker build of dapple instead of installing it locally. Main advantage is much faster builds since we don't build dapple locally each time. Also avoids solc-js.

Currently links to a docker image that I've built (rainbeam/dapple).

Example PR with testing: https://github.com/rainbeam/maker-otc/pull/2

Travis output: https://travis-ci.org/rainbeam/maker-otc/builds/123569408

How much faster? 1m17s (with docker) vs. 4m38s (no docker). 

TODO:

- [ ] push docker image to canonical location