### PR TITLE
Rename buy(id, quantity) to buyPartial

### DIFF
--- a/contracts/atomic_trade.sol
+++ b/contracts/atomic_trade.sol
@@ -61,7 +61,7 @@ contract AtomicTrade is MakerUser, ItemUpdateEvent, FallbackFailer, Assertive {
         delete offers[id];
         ItemUpdate(id);
     }
-    function buy( uint id, uint quantity )
+    function buyPartial( uint id, uint quantity )
     {
         var offer = offers[id];
         assert(offer.active);

--- a/contracts/atomic_trade_test.sol
+++ b/contracts/atomic_trade_test.sol
@@ -47,7 +47,7 @@ contract AtomicTradeTest is Test
         var user1_dai_balance_before = balanceOf(user1, "DAI");
 
         var id = otc.offer( 200, "MKR", 500, "DAI" );
-        AtomicTrade(user1).buy(id, 10);
+        AtomicTrade(user1).buyPartial(id, 10);
         var my_mkr_balance_after = balanceOf(this, "MKR");
         var my_dai_balance_after = balanceOf(this, "DAI");
         var user1_mkr_balance_after = balanceOf(user1, "MKR");
@@ -76,7 +76,7 @@ contract AtomicTradeTest is Test
         var user1_dai_balance_before = balanceOf(user1, "DAI");
 
         var id = otc.offer( 500, "DAI", 200, "MKR" );
-        AtomicTrade(user1).buy(id, 10);
+        AtomicTrade(user1).buyPartial(id, 10);
         var my_mkr_balance_after = balanceOf(this, "MKR");
         var my_dai_balance_after = balanceOf(this, "DAI");
         var user1_mkr_balance_after = balanceOf(user1, "MKR");

--- a/frontend/client/lib/offers.js
+++ b/frontend/client/lib/offers.js
@@ -111,7 +111,7 @@ Offers.newOffer = function (sell_how_much, sell_which_token, buy_how_much, buy_w
 
 Offers.buyOffer = function (idx) {
   var id = parseInt(idx, 10)
-  var tx = Dapple['maker-otc'].objects.otc.buy['uint256'](id, { gas: 3141592 })
+  var tx = Dapple['maker-otc'].objects.otc.buy(id, { gas: 3141592 })
   console.log('buy!', id, tx)
   Offers.update(idx, { $set: { status: Status.BOUGHT } })
 }


### PR DESCRIPTION
Rename buy(id, quantity) to buyPartial to improve readability and prevent overload issues