### PR TITLE
Log trade events

### DIFF
--- a/contracts/atomic_trade.sol
+++ b/contracts/atomic_trade.sol
@@ -52,14 +52,18 @@ contract AtomicTrade is MakerUser, EventfulMarket, FallbackFailer, Assertive {
         ItemUpdate(id);
         return id;
     }
+    function trade( address maker, address taker, uint make_how_much, bytes32 make_which_token, uint take_how_much, bytes32 take_which_token ) internal
+    {
+        transferFrom( taker, maker, take_how_much, take_which_token );
+        transfer( taker, make_how_much, make_which_token );
+        Trade( make_how_much, make_which_token, take_how_much, take_which_token );
+    }
     function buy( uint id )
     {
         var offer = offers[id];
         assert(offer.active);
 
-        transferFrom( msg.sender, offer.owner, offer.buy_how_much, offer.buy_which_token );
-        transfer( msg.sender, offer.sell_how_much, offer.sell_which_token );
-        Trade( offer.sell_how_much, offer.sell_which_token, offer.buy_how_much, offer.buy_which_token );
+        trade( offer.owner, msg.sender, offer.sell_how_much, offer.sell_which_token, offer.buy_how_much, offer.buy_which_token );
 
         delete offers[id];
         ItemUpdate(id);
@@ -70,21 +74,17 @@ contract AtomicTrade is MakerUser, EventfulMarket, FallbackFailer, Assertive {
         assert(offer.active);
 
         if ( offers[id].sell_how_much <= quantity ) {
-            transferFrom( msg.sender, offer.owner, offer.buy_how_much, offer.buy_which_token );
-            transfer( msg.sender, offer.sell_how_much, offer.sell_which_token );
+            trade( offer.owner, msg.sender, offer.sell_how_much, offer.sell_which_token, offer.buy_how_much, offer.buy_which_token );
             delete offers[id];
 
-            Trade( offer.sell_how_much, offer.sell_which_token, offer.buy_how_much, offer.buy_which_token );
         } else {
             uint buy_quantity = quantity * offers[id].buy_how_much / offers[id].sell_how_much;
             if ( buy_quantity > 0 ) {
-                transferFrom( msg.sender, offer.owner, buy_quantity, offer.buy_which_token );
-                transfer( msg.sender, quantity, offer.sell_which_token );
+                trade( offer.owner, msg.sender, quantity, offer.sell_which_token, buy_quantity, offer.buy_which_token );
 
                 offer.sell_how_much -= quantity;
                 offer.buy_how_much -= buy_quantity;
 
-                Trade( quantity, offer.sell_which_token, buy_quantity, offer.buy_which_token );
             }
         }
         ItemUpdate(id);

--- a/contracts/atomic_trade_test.sol
+++ b/contracts/atomic_trade_test.sol
@@ -3,7 +3,7 @@ import 'atomic_trade.sol';
 
 contract AtomicTradeTest is Test
                            , MakerUserGeneric(new MakerUserMockRegistry())
-                           , ItemUpdateEvent
+                           , EventfulMarket
 {
     MakerUserTester user1;
     AtomicTrade otc;
@@ -35,6 +35,7 @@ contract AtomicTradeTest is Test
 
         expectEventsExact(otc);
         ItemUpdate(id);
+        Trade( 30, "MKR", 100, "DAI" );
         ItemUpdate(id);
     }
     function testPartiallyFilledOrderMkr() {
@@ -63,6 +64,7 @@ contract AtomicTradeTest is Test
 
         expectEventsExact(otc);
         ItemUpdate(id);
+        Trade( 10, "MKR", 25, "DAI" );
         ItemUpdate(id);
     }
     function testPartiallyFilledOrderDai() {
@@ -92,6 +94,7 @@ contract AtomicTradeTest is Test
 
         expectEventsExact(otc);
         ItemUpdate(id);
+        Trade( 10, "DAI", 4, "MKR" );
         ItemUpdate(id);
     }
     function testCancel() {


### PR DESCRIPTION
Any exchange now emits a trade event that can be used to form market
history. Fixes #48.