### PR TITLE
Use minimal dapple

### DIFF
--- a/.travis.dapple-docker-entry
+++ b/.travis.dapple-docker-entry
@@ -1,6 +1,6 @@
 #!/bin/sh
 exec docker run --rm -it --name=dapple-$$ \
--e HOME -e USER=travis -e GROUP=`id -gn` \
+-e HOME -e USER=`id -un` -e GROUP=`id -gn` \
 -e entrypoint -w "`pwd`" -v "`pwd`:`pwd`" \
 -v "$HOME/.dapplerc:$HOME/.dapplerc" \
 -v "$HOME/.npm:$HOME/.npm" \

--- a/.travis.dapple-docker-entry
+++ b/.travis.dapple-docker-entry
@@ -4,4 +4,4 @@ exec docker run --rm -it --name=dapple-$$ \
 -e entrypoint -w "`pwd`" -v "`pwd`:`pwd`" \
 -v "$HOME/.dapplerc:$HOME/.dapplerc" \
 -v "$HOME/.npm:$HOME/.npm" \
-rainbeam/dapple "$@"
+rainbeam/dapple-minimal:alpine "$@"

--- a/.travis.dapple-docker-entry
+++ b/.travis.dapple-docker-entry
@@ -3,5 +3,4 @@ exec docker run --rm -it --name=dapple-$$ \
 -e HOME -e USER=`id -un` -e GROUP=`id -gn` \
 -e entrypoint -w "`pwd`" -v "`pwd`:`pwd`" \
 -v "$HOME/.dapplerc:$HOME/.dapplerc" \
--v "$HOME/.npm:$HOME/.npm" \
 rainbeam/dapple-minimal:alpine "$@"

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
 
 before_install:
   - id
-  - if [ $TEST = "dapple" ]; then docker pull rainbeam/dapple && docker images; fi
+  - if [ $TEST = "dapple" ]; then docker pull rainbeam/dapple-minimal && docker images; fi
   - cp .travis.dapplerc $HOME/.dapplerc
 
 install:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 ---
 [![Slack Status](http://slack.makerdao.com/badge.svg)](https:/slack.makerdao.com)
 [![Stories in Ready](https://badge.waffle.io/MakerDAO/maker-otc.png?label=ready&title=Ready)](https://waffle.io/MakerDAO/maker-otc)
+[![Build Status](https://travis-ci.org/makerdao/maker-otc.svg?branch=master)](https://travis-ci.org/makerdao/maker-otc)
 
 
 This is a simple on-chain OTC market for MKR. You can either pick an order from the order book (in which case delivery will happen instantly), or submit a new order yourself.


### PR DESCRIPTION
Dapple test container is now a bit lighter weight (120MB vs 900MB). Despite the reduction in size it still contains `solc`, which is provided as a fully static binary.

Also added a build badge to the readme and some misc ci cleanup.

Addresses part of #34.