### PR TITLE
Price + dust offer vulnerability fixed

### DIFF
--- a/src/expiring_market.sol
+++ b/src/expiring_market.sol
@@ -27,7 +27,7 @@ contract ExpiringMarket is DSAuth, SimpleMarket {
     // after close, anyone can cancel an offer
     modifier can_cancel(uint id) {
         require(isActive(id));
-        require(isClosed() || (msg.sender == getOwner(id) || dust_id == id));
+        require(isClosed() || (msg.sender == getOwner(id)));
         _;
     }
 

--- a/src/expiring_market.sol
+++ b/src/expiring_market.sol
@@ -27,7 +27,7 @@ contract ExpiringMarket is DSAuth, SimpleMarket {
     // after close, anyone can cancel an offer
     modifier can_cancel(uint id) {
         require(isActive(id));
-        require(isClosed() || (msg.sender == getOwner(id)));
+        require(isClosed() || (msg.sender == getOwner(id) || dust_id == id));
         _;
     }
 

--- a/src/matching_market.t.sol
+++ b/src/matching_market.t.sol
@@ -94,15 +94,6 @@ contract MarketTester {
         return market.offer(pay_amt, pay_gem,
                   buy_amt, buy_gem, pos);
     }
-    function doOffer(uint pay_amt, ERC20 pay_gem,
-                    uint buy_amt,  ERC20 buy_gem,
-                    uint pos, bool rounding)
-        public
-        returns (uint)
-    {
-        return market.offer(pay_amt, pay_gem,
-                  buy_amt, buy_gem, pos, rounding);
-    }
     function doCancel(uint id) public returns (bool _success) {
         return market.cancel(id);
     }
@@ -676,7 +667,7 @@ contract OrderMatchingTest is DSTest, EventfulMarket, MatchingEvents {
 
         // `false` and `true` both allow rounding to a slightly higher price
         // in order to find a match.
-        user1.doOffer(dai_pay, dai, dgd_buy, dgd, 0, true);
+        user1.doOffer(dai_pay, dai, dgd_buy, dgd, 0);
 
         // We should have paid a bit more than we offered to pay.
         uint expected_overpay = 651528437;
@@ -697,7 +688,7 @@ contract OrderMatchingTest is DSTest, EventfulMarket, MatchingEvents {
         mkr.approve(otc, MKR_SUPPLY);
 
         // Does not divide cleanly.
-        otc.offer(1504155374, dgd, 18501111110000000000, dai, 0, false);
+        otc.offer(1504155374, dgd, 18501111110000000000, dai, 0);
 
         uint old_dai_bal = dai.balanceOf(user1);
         uint old_dgd_bal = dgd.balanceOf(user1);
@@ -706,7 +697,7 @@ contract OrderMatchingTest is DSTest, EventfulMarket, MatchingEvents {
 
         // `false` and `true` both allow rounding to a slightly higher price
         // in order to find a match.
-        user1.doOffer(dai_pay, dai, dgd_buy, dgd, 0, true);
+        user1.doOffer(dai_pay, dai, dgd_buy, dgd, 0);
 
         // We should have paid a bit more than we offered to pay.
         uint expected_overpay = 651528437;
@@ -1452,7 +1443,7 @@ contract OrderMatchingTest is DSTest, EventfulMarket, MatchingEvents {
         var my_dai_balance_after = dai.balanceOf(this);
         var user1_mkr_balance_after = mkr.balanceOf(user1);
         var user1_dai_balance_after = dai.balanceOf(user1);
-        (sell_val, sell_token, buy_val, buy_token) = otc.getOffer(offer_id[1]);
+        (, sell_val, sell_token, , buy_val, buy_token) = otc.getOffer(offer_id[1]);
 
         assertEq(my_mkr_balance_before - my_mkr_balance_after, 200);
         assertEq(my_dai_balance_after - my_dai_balance_before, 50);
@@ -1484,8 +1475,8 @@ contract OrderMatchingTest is DSTest, EventfulMarket, MatchingEvents {
         var my_dai_balance_after = dai.balanceOf(this);
         var user1_mkr_balance_after = mkr.balanceOf(user1);
         var user1_dai_balance_after = dai.balanceOf(user1);
-         (sell_val, sell_token, buy_val, buy_token) = otc.getOffer(offer_id[1]);
-         (sell_val1, sell_token1, buy_val1, buy_token1) = otc.getOffer(offer_id[2]);
+         (, sell_val, sell_token, , buy_val, buy_token) = otc.getOffer(offer_id[1]);
+         (, sell_val1, sell_token1, , buy_val1, buy_token1) = otc.getOffer(offer_id[2]);
 
         assertEq(my_mkr_balance_before - my_mkr_balance_after, 200);
         assertEq(my_dai_balance_after - my_dai_balance_before, 500 );
@@ -1521,7 +1512,7 @@ contract OrderMatchingTest is DSTest, EventfulMarket, MatchingEvents {
         mkr.approve(otc, 10);
         offer_id[1] = user1.doOffer(5, dai, 1, mkr);
         offer_id[2] = otc.offer(10, mkr, 10, dai, 0);
-        (sell_val, sell_token, buy_val, buy_token) = otc.getOffer(offer_id[2]);
+        (,sell_val, sell_token, , buy_val, buy_token) = otc.getOffer(offer_id[2]);
 
         assertEq(otc.getBestOffer(dai, mkr), 0);
         assertEq(otc.getBetterOffer(offer_id[1]), 0);
@@ -1541,7 +1532,7 @@ contract OrderMatchingTest is DSTest, EventfulMarket, MatchingEvents {
         dai.approve(otc, 5);
         offer_id[1] = user1.doOffer( 10, mkr, 10, dai);
         offer_id[2] = otc.offer(5, dai, 5, mkr, 0);
-        (sell_val, sell_token, buy_val, buy_token) = otc.getOffer(offer_id[1]);
+        (,sell_val, sell_token, , buy_val, buy_token) = otc.getOffer(offer_id[1]);
 
         assertEq(otc.getBestOffer(dai, mkr), 0);
         assertEq(otc.getBestOffer(mkr, dai), offer_id[1]);
@@ -1564,7 +1555,7 @@ contract OrderMatchingTest is DSTest, EventfulMarket, MatchingEvents {
         offer_id[1] = user1.doOffer(5, dai, 1, mkr);
         offer_id[1] = user1.doOffer(4, dai, 1, mkr);
         offer_id[2] = otc.offer(10, mkr, 10, dai, 0);
-        (sell_val, sell_token, buy_val, buy_token) = otc.getOffer(offer_id[2]);
+        (,sell_val, sell_token, , buy_val, buy_token) = otc.getOffer(offer_id[2]);
 
         assertEq(otc.getBestOffer(dai, mkr), 0);
         assertEq(otc.getBetterOffer(offer_id[1]), 0);
@@ -1584,7 +1575,7 @@ contract OrderMatchingTest is DSTest, EventfulMarket, MatchingEvents {
         dai.approve(otc, 10);
         offer_id[1] = user1.doOffer(5, mkr, 5, dai);
         offer_id[2] = otc.offer(10, dai, 10, mkr, 0);
-        (sell_val, sell_token, buy_val, buy_token) = otc.getOffer(offer_id[2]);
+        (,sell_val, sell_token, ,buy_val, buy_token) = otc.getOffer(offer_id[2]);
 
         assertEq( otc.getBestOffer(dai, mkr), offer_id[2]);
         assertEq( otc.getBestOffer(mkr, dai), 0);
@@ -1607,8 +1598,8 @@ contract OrderMatchingTest is DSTest, EventfulMarket, MatchingEvents {
         offer_id[1] = user1.doOffer(5, mkr, 10, dai);
         offer_id[2] = user1.doOffer(10, mkr, 10, dai);
         offer_id[3] = otc.offer(1, dai, 1, mkr, 0);
-        (sell_val, sell_token, buy_val, buy_token) = otc.getOffer(offer_id[1]);
-        (sell_val1, sell_token1, buy_val1, buy_token1) = otc.getOffer(offer_id[2]);
+        (, sell_val, sell_token, , buy_val, buy_token) = otc.getOffer(offer_id[1]);
+        (, sell_val1, sell_token1, , buy_val1, buy_token1) = otc.getOffer(offer_id[2]);
 
         assertEq(otc.getBestOffer(mkr, dai), offer_id[2]);
         assertEq(otc.getBestOffer(dai, mkr), 0);
@@ -1635,8 +1626,8 @@ contract OrderMatchingTest is DSTest, EventfulMarket, MatchingEvents {
         offer_id[1] = user1.doOffer(5, mkr, 10, dai);
         offer_id[2] = user1.doOffer(1, mkr, 1, dai);
         offer_id[3] = otc.offer(10, dai, 10, mkr, 0);
-        (sell_val, sell_token, buy_val, buy_token) = otc.getOffer(offer_id[1]);
-        (sell_val1, sell_token1, buy_val1, buy_token1) = otc.getOffer(offer_id[3]);
+        (, sell_val, sell_token, , buy_val, buy_token) = otc.getOffer(offer_id[1]);
+        (, sell_val1, sell_token1, , buy_val1, buy_token1) = otc.getOffer(offer_id[3]);
 
         assertEq(otc.getBestOffer(mkr, dai), offer_id[1]);
         assertEq(otc.getBestOffer(dai, mkr), offer_id[3]);
@@ -1666,8 +1657,8 @@ contract OrderMatchingTest is DSTest, EventfulMarket, MatchingEvents {
         offer_id[2] = otc.offer(1, mkr,  1, dai, 0);
         offer_id[3] = otc.offer(10, mkr, 10, dai, 0);
         offer_id[4] = user1.doOffer(3, dai, 3, mkr);
-        (sell_val, sell_token, buy_val, buy_token) = otc.getOffer(offer_id[3]);
-        (sell_val1, sell_token1, buy_val1, buy_token1) = otc.getOffer(offer_id[1]);
+        (,sell_val, sell_token, , buy_val, buy_token) = otc.getOffer(offer_id[3]);
+        (,sell_val1, sell_token1, , buy_val1, buy_token1) = otc.getOffer(offer_id[1]);
 
         assertEq(otc.getBestOffer(mkr, dai), offer_id[3]);
         assertEq(otc.getBestOffer(dai, mkr), 0);

--- a/src/simple_market.sol
+++ b/src/simple_market.sol
@@ -62,8 +62,6 @@ contract SimpleMarket is EventfulMarket, DSMath {
 
     bool locked;
 
-    uint dust_id;
-
     struct OfferInfo {
         uint     o_pay_amt; //original pay_amt, always calculate price with this
         uint     o_buy_amt; //original buy_amt, always calculate price with this
@@ -82,7 +80,7 @@ contract SimpleMarket is EventfulMarket, DSMath {
 
     modifier can_cancel(uint id) {
         require(isActive(id));
-        require(getOwner(id) == msg.sender || id == dust_id);
+        require(getOwner(id) == msg.sender);
         _;
     }
 
@@ -114,13 +112,7 @@ contract SimpleMarket is EventfulMarket, DSMath {
         return offers[id].owner;
     }
 
-    function getOffer(uint id) public constant returns (uint, ERC20, uint, ERC20) {
-      var offer = offers[id];
-      return (offer.pay_amt, offer.pay_gem,
-              offer.buy_amt, offer.buy_gem);
-    }
-
-    function getOfferAll(uint id) public constant returns (uint, uint, ERC20, uint, uint, ERC20) {
+    function getOffer(uint id) public constant returns (uint, uint, ERC20, uint, uint, ERC20) {
       var offer = offers[id];
       return (offer.o_pay_amt, offer.pay_amt, offer.pay_gem,
               offer.o_buy_amt, offer.buy_amt, offer.buy_gem);

--- a/src/simple_market.sol
+++ b/src/simple_market.sol
@@ -97,6 +97,15 @@ contract SimpleMarket is EventfulMarket, DSMath {
         locked = false;
     }
 
+    function _next_id()
+        internal
+        returns (uint)
+    {
+        last_offer_id++; return last_offer_id;
+    }
+
+    // ---- Public entrypoints ---- //
+
     function isActive(uint id) public constant returns (bool active) {
         return offers[id].timestamp > 0;
     }
@@ -116,7 +125,6 @@ contract SimpleMarket is EventfulMarket, DSMath {
       return (offer.o_pay_amt, offer.pay_amt, offer.pay_gem,
               offer.o_buy_amt, offer.buy_amt, offer.buy_gem);
     }
-    // ---- Public entrypoints ---- //
 
     // Accept given `quantity` of an offer. Transfers funds from caller to
     // offer maker, and from market to caller.
@@ -257,12 +265,5 @@ contract SimpleMarket is EventfulMarket, DSMath {
         public
     {
         require(buy(uint256(id), maxTakeAmount));
-    }
-
-    function _next_id()
-        internal
-        returns (uint)
-    {
-        last_offer_id++; return last_offer_id;
     }
 }

--- a/src/simple_market.t.sol
+++ b/src/simple_market.t.sol
@@ -13,6 +13,14 @@ contract MarketTester {
     function doApprove(address spender, uint value, ERC20 token) public {
         token.approve(spender, value);
     }
+    function doOffer(uint pay_amt, ERC20 pay_gem,
+                    uint buy_amt,  ERC20 buy_gem)
+        public
+        returns (uint)
+    {
+        return market.offer(pay_amt, pay_gem,
+                  buy_amt, buy_gem);
+    }
     function doBuy(uint id, uint buy_how_much) public returns (bool _success) {
         return market.buy(id, buy_how_much);
     }
@@ -33,6 +41,29 @@ contract SimpleMarketTest is DSTest, EventfulMarket {
         dai = new DSTokenBase(10 ** 9);
         mkr = new DSTokenBase(10 ** 6);
     }
+    function testOriginalPayAndBuySet() public {
+        uint o_pay_amt;
+        uint o_buy_amt;
+        dai.transfer(user1, 100);
+        user1.doApprove(otc, 100, dai);
+        uint id0 = user1.doOffer(100, dai, 100, mkr);
+        (o_pay_amt,o_buy_amt,,,,)=otc.getOfferAll(id0);
+        assert( o_pay_amt == 100 );
+        assert( o_buy_amt == 100 );
+    }
+    function testOriginalPayAndBuyUnchanged() public {
+        uint o_pay_amt;
+        uint o_buy_amt;
+        dai.transfer(user1, 100);
+        user1.doApprove(otc, 100, dai);
+        mkr.approve(otc, 10);
+        uint id0 = user1.doOffer(100, dai, 100, mkr);
+        otc.offer(10, mkr, 10, dai);
+        (o_pay_amt,o_buy_amt,,,,)=otc.getOfferAll(id0);
+        assert( o_pay_amt == 100 );
+        assert( o_buy_amt == 100 );
+    }
+
     function testBasicTrade() public {
         dai.transfer(user1, 100);
         user1.doApprove(otc, 100, dai);

--- a/src/simple_market.t.sol
+++ b/src/simple_market.t.sol
@@ -47,7 +47,7 @@ contract SimpleMarketTest is DSTest, EventfulMarket {
         dai.transfer(user1, 100);
         user1.doApprove(otc, 100, dai);
         uint id0 = user1.doOffer(100, dai, 100, mkr);
-        (o_pay_amt,o_buy_amt,,,,)=otc.getOfferAll(id0);
+        (o_pay_amt,o_buy_amt,,,,)=otc.getOffer(id0);
         assert( o_pay_amt == 100 );
         assert( o_buy_amt == 100 );
     }
@@ -59,7 +59,7 @@ contract SimpleMarketTest is DSTest, EventfulMarket {
         mkr.approve(otc, 10);
         uint id0 = user1.doOffer(100, dai, 100, mkr);
         otc.offer(10, mkr, 10, dai);
-        (o_pay_amt,o_buy_amt,,,,)=otc.getOfferAll(id0);
+        (o_pay_amt,o_buy_amt,,,,)=otc.getOffer(id0);
         assert( o_pay_amt == 100 );
         assert( o_buy_amt == 100 );
     }
@@ -106,7 +106,7 @@ contract SimpleMarketTest is DSTest, EventfulMarket {
         var my_dai_balance_after = dai.balanceOf(this);
         var user1_mkr_balance_after = mkr.balanceOf(user1);
         var user1_dai_balance_after = dai.balanceOf(user1);
-        var (sell_val, sell_token, buy_val, buy_token) = otc.getOffer(id);
+        var (, sell_val, sell_token, , buy_val, buy_token) = otc.getOffer(id);
 
         assertEq(200, my_mkr_balance_before - my_mkr_balance_after);
         assertEq(25, my_dai_balance_after - my_dai_balance_before);
@@ -138,7 +138,7 @@ contract SimpleMarketTest is DSTest, EventfulMarket {
         var my_dai_balance_after = dai.balanceOf(this);
         var user1_mkr_balance_after = mkr.balanceOf(user1);
         var user1_dai_balance_after = dai.balanceOf(user1);
-        var (sell_val, sell_token, buy_val, buy_token) = otc.getOffer(id);
+        var (, sell_val, sell_token, , buy_val, buy_token) = otc.getOffer(id);
 
         assertEq(500, my_dai_balance_before - my_dai_balance_after);
         assertEq(4, my_mkr_balance_after - my_mkr_balance_before);
@@ -171,7 +171,7 @@ contract SimpleMarketTest is DSTest, EventfulMarket {
         var my_dai_balance_after = dai.balanceOf(this);
         var user1_mkr_balance_after = mkr.balanceOf(user1);
         var user1_dai_balance_after = dai.balanceOf(user1);
-        var (sell_val, sell_token, buy_val, buy_token) = otc.getOffer(id);
+        var (, sell_val, sell_token, , buy_val, buy_token) = otc.getOffer(id);
 
         assertEq(0, my_dai_balance_before - my_dai_balance_after);
         assertEq(200, my_mkr_balance_before - my_mkr_balance_after);


### PR DESCRIPTION
fixed bug: price changed when offer was partially matched
Matcher now leaves no dust offers, vulnerability is gone.
LogBump() has been removed.
offer(,,,rounding) function is now deprecated, the rounding will be on no matter what the user chooses.
Reorganized simple market to separate public and non-public methods.
Used mul() instead of '+' in matching market to avoid possible exploits. 