### PR TITLE
optimize synchronized modifier

### DIFF
--- a/src/simple_market.sol
+++ b/src/simple_market.sol
@@ -76,7 +76,7 @@ contract SimpleMarket is EventfulMarket, DSMath {
 
     mapping (uint => OfferInfo) public offers;
 
-    bool locked;
+    uint lock_nonce;
 
     struct OfferInfo {
         uint     pay_amt;
@@ -103,10 +103,10 @@ contract SimpleMarket is EventfulMarket, DSMath {
     }
 
     modifier synchronized {
-        require(!locked);
-        locked = true;
+        lock_nonce += 1;
+        uint local_lock_nonce = lock_nonce;
         _;
-        locked = false;
+        require(local_lock_nonce == lock_nonce);
     }
 
     function isActive(uint id) public constant returns (bool active) {


### PR DESCRIPTION
Makes the synchronized modifier closer to the current NonReentrant modifier in zeppelin-solidity. https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/contracts/utils/ReentrancyGuard.sol

Saves an SSTORE operation per contract call (roughly 5000 gas). May save thousands of USD in gas fees for Market Makers in the long term. Does not change any interfaces.