### PR TITLE
optimize can_cancel modifier

### DIFF
--- a/src/expiring_market.sol
+++ b/src/expiring_market.sol
@@ -43,7 +43,7 @@ contract ExpiringMarket is DSAuth, SimpleMarket {
     // after close, anyone can cancel an offer
     modifier can_cancel(uint id) {
         require(isActive(id));
-        require(isClosed() || (msg.sender == getOwner(id)));
+        require((msg.sender == getOwner(id)) || isClosed());
         _;
     }
 


### PR DESCRIPTION
Save an extra SLOAD in most cases for canceling offers. Can save hundreds in USD gas fees for Market Makers over the long term.

edit: actually saves 2 SLOAD calls while the exchange is operational